### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/formats/swf.cpp
+++ b/formats/swf.cpp
@@ -220,7 +220,7 @@ size_t Swf::Leanify(size_t size_leanified /*= 0*/) {
 
   // free decompressed data
   if (*fp_ == 'C')
-    free(in_buffer);
+    delete[] in_buffer;
   else if (*fp_ == 'Z')
     delete[] in_buffer;
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new' operator but was released using the 'free' function. Consider inspecting operation logics behind the 'in_buffer' variable. swf.cpp 223