### PR TITLE
Fix undefined reference to PathRemoveFileSpec()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LDFLAGS     += -flto -lpthread
 
 ifeq ($(OS), Windows_NT)
     SYSTEM  := Windows
+    LDLIBS  += -lshlwapi
 else
     SYSTEM  := $(shell uname -s)
 endif


### PR DESCRIPTION
On Windows, compiling with MinGW produces undefined reference to `::PathRemoveFileSpecW()` due to not being linked to `shlwapi`. This patch fixes that.

```cpp
> mingw32-make -f Makefile -j4
E:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\Florastamine\AppData\Local\Temp\leanify.exe.8FLneM.ltrans9.ltrans.o:<artificial>:(.text+0xdb3): undefined reference to `__imp_PathRemoveFileSpecW'
collect2.exe: error: ld returned 1 exit status
mingw32-make: *** [Makefile:43: leanify] Error 1
```

Tested on `gcc (Rev9, Built by MSYS2 project) 10.2.0`, but I've seen this issue from as early as 7.1.