### PR TITLE
Added --png-lossy-transparent switch.

### DIFF
--- a/formats/png.cpp
+++ b/formats/png.cpp
@@ -15,7 +15,7 @@ using std::cout;
 using std::endl;
 using std::vector;
 
-extern bool zopfli_lossy_transparent;
+extern bool zopflipng_lossy_transparent;
 
 const uint8_t Png::header_magic[] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
 bool Png::keep_icc_profile_ = false;
@@ -110,7 +110,7 @@ size_t Png::Leanify(size_t size_leanified /*= 0*/) {
   {
     ZopfliPNGOptions zopflipng_options;
     zopflipng_options.use_zopfli = !is_fast;
-    zopflipng_options.lossy_transparent = zopfli_lossy_transparent;
+    zopflipng_options.lossy_transparent = zopflipng_lossy_transparent;
     // see the switch above for information about these chunks
     zopflipng_options.keepchunks = { "acTL", "fcTL", "fdAT", "npTc" };
     if (keep_icc_profile_)

--- a/formats/png.cpp
+++ b/formats/png.cpp
@@ -15,7 +15,7 @@ using std::cout;
 using std::endl;
 using std::vector;
 
-extern bool zopfly_lossy_transparent;
+extern bool zopfli_lossy_transparent;
 
 const uint8_t Png::header_magic[] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
 bool Png::keep_icc_profile_ = false;
@@ -110,7 +110,7 @@ size_t Png::Leanify(size_t size_leanified /*= 0*/) {
   {
     ZopfliPNGOptions zopflipng_options;
     zopflipng_options.use_zopfli = !is_fast;
-    zopflipng_options.lossy_transparent = zopfly_lossy_transparent;
+    zopflipng_options.lossy_transparent = zopfli_lossy_transparent;
     // see the switch above for information about these chunks
     zopflipng_options.keepchunks = { "acTL", "fcTL", "fdAT", "npTc" };
     if (keep_icc_profile_)

--- a/formats/png.cpp
+++ b/formats/png.cpp
@@ -15,6 +15,8 @@ using std::cout;
 using std::endl;
 using std::vector;
 
+extern bool zopfly_lossy_transparent;
+
 const uint8_t Png::header_magic[] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
 bool Png::keep_icc_profile_ = false;
 
@@ -108,7 +110,7 @@ size_t Png::Leanify(size_t size_leanified /*= 0*/) {
   {
     ZopfliPNGOptions zopflipng_options;
     zopflipng_options.use_zopfli = !is_fast;
-    zopflipng_options.lossy_transparent = true;
+    zopflipng_options.lossy_transparent = zopfly_lossy_transparent;
     // see the switch above for information about these chunks
     zopflipng_options.keepchunks = { "acTL", "fcTL", "fdAT", "npTc" };
     if (keep_icc_profile_)

--- a/main.cpp
+++ b/main.cpp
@@ -116,6 +116,8 @@ void PrintInfo() {
           "  --jpeg-keep-all               Do not remove any metadata or comments in JPEG.\n"
           "  --jpeg-arithmetic             Use arithmetic coding for JPEG.\n"
           "\n"
+          "PNG options:\n"
+          "  --png-lossy-transparent       Allow altering hidden colors of fully transparent pixels.\n"
           "ZIP options:\n"
           "  --zip-deflate                 Try deflate even if not compressed originally.\n";
 
@@ -157,6 +159,7 @@ int main(int argc, char** argv) {
   iterations = 15;
   depth = 1;
   max_depth = INT_MAX;
+  zopfly_lossy_transparent = false;
 
 #ifdef _WIN32
   is_pause = !getenv("PROMPT");
@@ -239,6 +242,9 @@ int main(int argc, char** argv) {
           } else if (STRCMP(argv[i] + j + 1, "jpeg-arithmetic") == 0) {
             j += 15;
             Jpeg::force_arithmetic_coding_ = true;
+          } else if (STRCMP(argv[i] + j + 1, "png-lossy-transparent") == 0) {
+            j += 21;
+            zopfly_lossy_transparent = false;
           } else if (STRCMP(argv[i] + j + 1, "zip-deflate") == 0) {
             j += 11;
             Zip::force_deflate_ = true;

--- a/main.cpp
+++ b/main.cpp
@@ -117,7 +117,7 @@ void PrintInfo() {
           "  --jpeg-arithmetic             Use arithmetic coding for JPEG.\n"
           "\n"
           "PNG options:\n"
-          "  --png-lossy-transparent       Allow altering hidden colors of fully transparent pixels.\n"
+          "  --png-lossless-transparent    Prohibit altering hidden colors of fully transparent pixels.\n"
           "ZIP options:\n"
           "  --zip-deflate                 Try deflate even if not compressed originally.\n";
 
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
   iterations = 15;
   depth = 1;
   max_depth = INT_MAX;
-  zopfly_lossy_transparent = false;
+  zopfli_lossy_transparent = true;
 
 #ifdef _WIN32
   is_pause = !getenv("PROMPT");
@@ -242,9 +242,9 @@ int main(int argc, char** argv) {
           } else if (STRCMP(argv[i] + j + 1, "jpeg-arithmetic") == 0) {
             j += 15;
             Jpeg::force_arithmetic_coding_ = true;
-          } else if (STRCMP(argv[i] + j + 1, "png-lossy-transparent") == 0) {
-            j += 21;
-            zopfly_lossy_transparent = false;
+          } else if (STRCMP(argv[i] + j + 1, "png-lossless-transparent") == 0) {
+            j += 24;
+            zopfli_lossy_transparent = false;
           } else if (STRCMP(argv[i] + j + 1, "zip-deflate") == 0) {
             j += 11;
             Zip::force_deflate_ = true;

--- a/main.cpp
+++ b/main.cpp
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
   iterations = 15;
   depth = 1;
   max_depth = INT_MAX;
-  zopfli_lossy_transparent = true;
+  zopflipng_lossy_transparent = true;
 
 #ifdef _WIN32
   is_pause = !getenv("PROMPT");
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
             Jpeg::force_arithmetic_coding_ = true;
           } else if (STRCMP(argv[i] + j + 1, "png-lossless-transparent") == 0) {
             j += 24;
-            zopfli_lossy_transparent = false;
+            zopflipng_lossy_transparent = false;
           } else if (STRCMP(argv[i] + j + 1, "zip-deflate") == 0) {
             j += 11;
             Zip::force_deflate_ = true;

--- a/main.h
+++ b/main.h
@@ -18,6 +18,9 @@ bool is_pause;
 // iteration of zopfli
 int iterations;
 
+// Allow altering hidden colors of fully transparent pixels, only for zopfli
+bool zopfly_lossy_transparent;
+
 // a normal file: depth 1
 // file inside zip that is inside another zip: depth 3
 int depth;

--- a/main.h
+++ b/main.h
@@ -19,7 +19,7 @@ bool is_pause;
 int iterations;
 
 // Allow altering hidden colors of fully transparent pixels, only for zopfli
-bool zopfli_lossy_transparent;
+bool zopflipng_lossy_transparent;
 
 // a normal file: depth 1
 // file inside zip that is inside another zip: depth 3

--- a/main.h
+++ b/main.h
@@ -19,7 +19,7 @@ bool is_pause;
 int iterations;
 
 // Allow altering hidden colors of fully transparent pixels, only for zopfli
-bool zopfly_lossy_transparent;
+bool zopfli_lossy_transparent;
 
 // a normal file: depth 1
 // file inside zip that is inside another zip: depth 3


### PR DESCRIPTION
Added --png-lossy-transparent switch to allow altering hidden colors of fully transparent pixels.

By default leanify behaves lossless to prevent confusion when you are working with textures with premultiplied alpha or packed lookup tables in textures.

Warning: default behavoiur has changed!

resolves JayXon/Leanify#68