### PR TITLE
Fix compilation with gcc 13.1.1

### DIFF
--- a/leanify.h
+++ b/leanify.h
@@ -2,6 +2,7 @@
 #define LEANIFY_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 extern int depth;


### PR DESCRIPTION
With gcc 12, this change is not needed. With gcc 13.1.1, the compilation fails without this change:
```
g++ -Wall -Werror -O3 -flto -Wextra -Wno-unused-parameter -std=c++17 -fno-rtti -I./lib  -c -o leanify.o leanify.cpp
In file included from leanify.cpp:1:
leanify.h:12:23: error: 'uint8_t' was not declared in this scope
   12 | size_t ZlibRecompress(uint8_t* src, size_t src_len, size_t size_leanified = 0);
      |                       ^~~~~~~
leanify.h:6:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    5 | #include <string>
  +++ |+#include <cstdint>
    6 |
leanify.h:12:32: error: 'src' was not declared in this scope
   12 | size_t ZlibRecompress(uint8_t* src, size_t src_len, size_t size_leanified = 0);
      |                                ^~~
leanify.h:12:44: error: expected primary-expression before 'src_len'
   12 | size_t ZlibRecompress(uint8_t* src, size_t src_len, size_t size_leanified = 0);
      |                                            ^~~~~~~
leanify.h:12:60: error: expected primary-expression before 'size_leanified'
   12 | size_t ZlibRecompress(uint8_t* src, size_t src_len, size_t size_leanified = 0);
      |                                                            ^~~~~~~~~~~~~~
leanify.h:12:78: error: expression list treated as compound expression in initializer [-fpermissive]
   12 | size_t ZlibRecompress(uint8_t* src, size_t src_len, size_t size_leanified = 0);
      |                                                                              ^
leanify.cpp:145:82: error: 'size_t ZlibRecompress(uint8_t*, size_t, size_t)' redeclared as different kind of entity
  145 | size_t ZlibRecompress(uint8_t* src, size_t src_len, size_t size_leanified /*= 0*/) {
      |                                                                                  ^
leanify.h:12:8: note: previous declaration 'size_t ZlibRecompress'
   12 | size_t ZlibRecompress(uint8_t* src, size_t src_len, size_t size_leanified = 0);
      |        ^~~~~~~~~~~~~~
make: *** [<builtin>: leanify.o] Error 1
```