### PR TITLE
Remove unused variable

### DIFF
--- a/lib/zopfli/squeeze.c
+++ b/lib/zopfli/squeeze.c
@@ -338,8 +338,6 @@ static void FollowPath(ZopfliBlockState* s,
   size_t windowstart = instart > ZOPFLI_WINDOW_SIZE
       ? instart - ZOPFLI_WINDOW_SIZE : 0;
 
-  size_t total_length_test = 0;
-
   if (instart == inend) return;
 
   ZopfliResetHash(ZOPFLI_WINDOW_SIZE, h);
@@ -366,11 +364,9 @@ static void FollowPath(ZopfliBlockState* s,
       assert(!(dummy_length != length && length > 2 && dummy_length > 2));
       ZopfliVerifyLenDist(in, inend, pos, dist, length);
       ZopfliStoreLitLenDist(length, dist, pos, store);
-      total_length_test += length;
     } else {
       length = 1;
       ZopfliStoreLitLenDist(in[pos], 0, pos, store);
-      total_length_test++;
     }
 
 

--- a/lib/zopflipng/lodepng/lodepng_util.cpp
+++ b/lib/zopflipng/lodepng/lodepng_util.cpp
@@ -1616,12 +1616,11 @@ struct ExtractZlib { // Zlib decompression and information extraction
 
   void inflateHuffmanBlock(std::vector<unsigned char>& out,
                            const unsigned char* in, size_t& bp, size_t& pos, size_t inlength, unsigned long btype) {
-    size_t numcodes = 0, numlit = 0, numlen = 0; //for logging
+    size_t numlit = 0, numlen = 0; //for logging
     if(btype == 1) { generateFixedTrees(codetree, codetreeD); }
     else if(btype == 2) { getTreeInflateDynamic(codetree, codetreeD, in, bp, inlength); if(error) return; }
     for(;;) {
       unsigned long code = huffmanDecodeSymbol(in, bp, codetree, inlength); if(error) return;
-      numcodes++;
       zlibinfo->back().lz77_lcode.push_back(code); //output code
       zlibinfo->back().lz77_dcode.push_back(0);
       zlibinfo->back().lz77_lbits.push_back(0);


### PR DESCRIPTION
Newer Clang complains about the unused variable, when it's never read, even if it's updated with `+=`.